### PR TITLE
Ichiran worker pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
 name = "ichiran"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "const_format",
  "csv-async",
  "enclose",
@@ -1551,13 +1552,13 @@ dependencies = [
  "par-stream",
  "regex",
  "serde",
- "serde-lexpr",
  "serde_json",
  "serde_path_to_error",
  "strum_macros",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "win32job",
 ]
 
@@ -1845,27 +1846,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lexpr"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a84de6a9df442363b08f5dbf0cd5b92edc70097b89c4ce4bfea4679fe48bc67"
-dependencies = [
- "itoa",
- "lexpr-macros",
- "ryu",
-]
-
-[[package]]
-name = "lexpr-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b5cb8bb985c81a8ac1a0f8b5c4865214f574ddd64397ef7a99c236e21f35bb"
-dependencies = [
- "proc-macro2",
- "quote",
-]
 
 [[package]]
 name = "libc"
@@ -3170,16 +3150,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-lexpr"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4cda13396159f59e7946118cdac0beadeecfb7cf76b197f4147e546f4ead6f"
-dependencies = [
- "lexpr",
- "serde",
 ]
 
 [[package]]

--- a/ichiran/Cargo.toml
+++ b/ichiran/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", features = ["process"] }
+tokio = { version = "1", features = ["process", "io-util", "sync", "macros", "fs"] }
+base64 = "0.22"
 futures = "0.3"
 par-stream = { version = "0.10.2", features = ["runtime-tokio"] }
 
@@ -15,7 +16,6 @@ tracing = "0.1"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde-lexpr = "0.1.3"
 thiserror = "2"
 csv-async = { version = "1.3", features = ["tokio"] }
 regex = "1"
@@ -33,3 +33,4 @@ win32job = "2.0.3"
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 serde_path_to_error = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/ichiran/examples/bench_parse.rs
+++ b/ichiran/examples/bench_parse.rs
@@ -1,0 +1,64 @@
+//! Steady-state parse-pathway benchmark.
+//!
+//! Mirrors what `niinii::Parser::parse` does: for each iteration runs
+//! `romanize` and `kanji_from_str` in parallel via `tokio::try_join!`.
+//! The pool is lazily initialized on the first call, so the first
+//! iteration includes worker startup; subsequent iterations are warm.
+//!
+//! Usage:
+//!     cargo run --release --example bench_parse -- [N] [TEXT]
+
+use std::{path::PathBuf, time::Instant};
+
+use ichiran::prelude::*;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
+    let mut args = std::env::args().skip(1);
+    let n: usize = args.next().as_deref().unwrap_or("5").parse().unwrap();
+
+    // Distinct sentences per iter to defeat `segment_cache`. Picked to roughly
+    // mirror visual-novel-line lengths.
+    let corpus: &[&str] = &[
+        "これは長い日本語の文章のテストです。",
+        "今日は晴れていて気持ちがいいですね。",
+        "彼女は静かに窓の外を眺めていた。",
+        "夕食は何にしましょうかと母が尋ねた。",
+        "雨が降り始めたので傘を持って出かけた。",
+        "新しい本を買ったので読むのが楽しみだ。",
+        "電車の中で偶然友達に会った。",
+        "公園で子供たちが楽しそうに遊んでいる。",
+        "明日の会議は十時から始まります。",
+        "猫が日向でゆっくりと眠っている。",
+    ];
+
+    let path = PathBuf::from("data/ichiran-cli").with_extension(std::env::consts::EXE_EXTENSION);
+    let ichiran = Ichiran::new(path, default_pool_size());
+
+    let total_start = Instant::now();
+    for i in 0..n {
+        let text = corpus[i % corpus.len()];
+        let splits: Vec<(Split, String)> = basic_split(text)
+            .into_iter()
+            .map(|(k, s)| (k, s.to_string()))
+            .collect();
+        let t = Instant::now();
+        let (_root, _kanji) = tokio::try_join!(
+            ichiran.romanize(&splits, 1),
+            ichiran.kanji_from_str(text),
+        )
+        .unwrap();
+        eprintln!("iter {}: {:.0?}", i, t.elapsed());
+    }
+    let elapsed = total_start.elapsed();
+    eprintln!(
+        "total: {:.0?}  mean/iter: {:.0?}",
+        elapsed,
+        elapsed / n as u32
+    );
+}

--- a/ichiran/src/error.rs
+++ b/ichiran/src/error.rs
@@ -1,19 +1,17 @@
-use std::{io, process::ExitStatus};
+use std::io;
 
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum IchiranError {
-    #[error("I/O Error: {0}")]
+    #[error("IO Error: {0}")]
     Io(#[from] io::Error),
-    #[error("JSON Error: {0}")]
-    Serde(#[from] serde_json::Error),
-    #[error("ichiran-cli exited w/ {status}\n{stderr}")]
-    Failure { status: ExitStatus, stderr: String },
-    #[error("Parse Error:\n{0}")]
-    Parsing(String),
     #[error("CSV Error: {0}")]
     CsvError(#[from] csv_async::Error),
-    #[error("Lexpr Error: {0}")]
-    SerdeLisp(#[from] serde_lexpr::Error),
+    #[error("JSON Error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("ichiran-cli server error: {0}")]
+    Server(String),
+    #[error("ichiran-cli server has gone away")]
+    ServerGone,
 }

--- a/ichiran/src/lib.rs
+++ b/ichiran/src/lib.rs
@@ -3,11 +3,11 @@ mod coerce;
 mod error;
 mod pgdaemon;
 mod protocol;
+mod server;
 pub mod split;
 
 use std::{
     collections::HashMap,
-    ffi::OsStr,
     io::{self, ErrorKind},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -19,8 +19,21 @@ use itertools::Itertools;
 use lru::LruCache;
 use nonzero_ext::nonzero;
 use par_stream::ParStreamExt;
-use tokio::process::Command;
+use tokio::sync::OnceCell;
 use tracing::{Instrument, Level};
+
+use crate::server::IchiranPool;
+
+/// Suggested default pool size: cap at 8 to avoid spinning up more
+/// resident `ichiran-cli` workers than there's parallel benefit for
+/// (a single parse fans out at most ~20 calls but the longest call
+/// caps the critical path).
+pub fn default_pool_size() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(8)
+}
 
 pub mod prelude {
     pub use crate::charset::*;
@@ -48,30 +61,18 @@ pub struct Ichiran {
 
 struct Shared {
     path: PathBuf,
+    pool_size: usize,
     state: Mutex<State>,
+    pool: OnceCell<IchiranPool>,
 }
 impl Shared {
     /// Evaluate the expression with ichiran and return the raw output.
-    async fn evaluate(&self, expr: impl AsRef<OsStr>) -> Result<String, IchiranError> {
-        let working_dir = self.working_dir()?;
-        let expr = expr.as_ref();
-        tracing::trace!(expr = ?expr);
-
-        let output = Command::new(&self.path)
-            .current_dir(working_dir)
-            .arg("-e")
-            .arg(expr)
-            .output()
+    async fn evaluate(&self, expr: impl Into<String>) -> Result<String, IchiranError> {
+        let pool = self
+            .pool
+            .get_or_try_init(|| IchiranPool::spawn(&self.path, self.pool_size))
             .await?;
-
-        if output.status.success() {
-            Ok(String::from_utf8(output.stdout).unwrap())
-        } else {
-            Err(IchiranError::Failure {
-                status: output.status,
-                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-            })
-        }
+        pool.evaluate(expr.into()).await
     }
     fn working_dir(&self) -> Result<&Path, io::Error> {
         Path::new(&self.path).parent().ok_or_else(|| {
@@ -86,12 +87,27 @@ impl Shared {
         let jmdict_path = self
             .evaluate(r#"(format t "~d" ichiran/dict::*jmdict-data*)"#)
             .await?;
-        let jmdict_path = jmdict_path
-            .lines()
-            .next()
-            .ok_or_else(|| IchiranError::Parsing(jmdict_path.clone()))?;
-        Ok(working_dir.join(jmdict_path))
+        Ok(working_dir.join(jmdict_path.trim()))
     }
+}
+
+/// Escape a Rust string into a Common Lisp `"..."` literal. Lisp string
+/// syntax only requires escaping `"` and `\`; everything else (including
+/// newlines and non-ASCII) is literal.
+fn lisp_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' | '\\' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 struct State {
@@ -101,15 +117,18 @@ struct State {
 }
 
 impl Ichiran {
-    pub fn new(path: impl Into<PathBuf>) -> Self {
+    pub fn new(path: impl Into<PathBuf>, pool_size: usize) -> Self {
+        assert!(pool_size >= 1, "pool size must be >= 1");
         Self {
             shared: Arc::new(Shared {
                 path: path.into(),
+                pool_size,
                 state: Mutex::new(State {
                     kanji_cache: LruCache::new(nonzero!(512usize)),
                     segment_cache: LruCache::new(nonzero!(512usize)),
                     jmdict: None,
                 }),
+                pool: OnceCell::new(),
             }),
         }
     }
@@ -163,12 +182,11 @@ impl Ichiran {
                     enclose! { (span, shared) async move {
                         let output = shared
                             .evaluate(format!(
-                                r#"(jsown:to-json (ichiran:romanize* {} :limit {}))"#,
-                                serde_lexpr::to_string(&split).unwrap(),
+                                r#"(princ (jsown:to-json (ichiran:romanize* {} :limit {})))"#,
+                                lisp_string(&split),
                                 limit
                             ))
                             .await?;
-                        let output: String = serde_lexpr::from_str(&output)?;
                         let root: Root = serde_json::from_str(&output)?;
                         assert_eq!(
                             root.segments().len(),
@@ -203,13 +221,17 @@ impl Ichiran {
 
     #[tracing::instrument(level = Level::DEBUG, skip_all, err)]
     pub async fn kanji(&self, chars: &[char]) -> Result<HashMap<char, Kanji>, IchiranError> {
-        let (mut kanji_info, query_chars): (HashMap<char, Kanji>, Vec<_>) = {
+        let (mut kanji_info, query_chars): (HashMap<char, Kanji>, Vec<char>) = {
             let kanji_cache = &mut self.shared.state.lock().unwrap().kanji_cache;
             let kanji_info = chars
                 .iter()
                 .filter_map(|c| kanji_cache.get(c).map(|kanji| (*c, kanji.clone())))
                 .collect();
-            let query_chars = chars.iter().filter(|c| !kanji_cache.contains(c)).collect();
+            let query_chars = chars
+                .iter()
+                .filter(|c| !kanji_cache.contains(c))
+                .copied()
+                .collect();
             (kanji_info, query_chars)
         };
 
@@ -217,21 +239,36 @@ impl Ichiran {
             return Ok(kanji_info);
         }
 
-        let commands: Vec<String> = query_chars
-            .iter()
-            .map(|c| format!(r#"(jsown:to-json (ichiran/kanji:kanji-info-json #\{}))"#, c))
-            .collect();
-
-        let expr = format!("(list {})", commands.join(" "));
-
-        let output = self.shared.evaluate(expr).await?;
-        let output: Vec<String> = serde_lexpr::from_str(&output)?;
+        // Fan out per char so the pool can dispatch them across workers in
+        // parallel. Previously these were batched into one (list ...) form
+        // which serialized through a single worker.
+        let shared = self.shared.clone();
+        let span = tracing::Span::current();
+        let results: Vec<(char, Option<Kanji>)> = stream::iter(query_chars)
+            .par_then_unordered(
+                None,
+                enclose! { (span, shared) move |c: char| {
+                    enclose! { (span, shared) async move {
+                        let expr = format!(
+                            r#"(princ (jsown:to-json (ichiran/kanji:kanji-info-json #\{})))"#,
+                            c
+                        );
+                        let output = shared.evaluate(expr).await?;
+                        let kanji = if output.trim() == "[]" {
+                            None
+                        } else {
+                            Some(serde_json::from_str::<Kanji>(&output)?)
+                        };
+                        Ok::<_, IchiranError>((c, kanji))
+                    }.instrument(span)}
+                }},
+            )
+            .try_collect()
+            .await?;
 
         let kanji_cache = &mut self.shared.state.lock().unwrap().kanji_cache;
-        for json in output {
-            if json != "[]" {
-                let kanji: Kanji = serde_json::from_str(&json)?;
-                let chr = kanji.text().chars().next().unwrap();
+        for (chr, maybe_kanji) in results {
+            if let Some(kanji) = maybe_kanji {
                 kanji_info.insert(chr, kanji.clone());
                 kanji_cache.put(chr, kanji);
             }
@@ -273,13 +310,12 @@ impl Ichiran {
             .shared
             .evaluate(r#"(format t "~{~a~^,~}" ichiran/conn::*connection*)"#)
             .await?;
-        let parse_error = || IchiranError::Parsing(conn_params.clone());
+        let parse_error = || IchiranError::Server(format!("parse error:\n{conn_params}"));
 
         let conn_params = conn_params
-            .lines()
-            .next()
-            .map(|x| x.split(','))
-            .and_then(|x| x.collect_tuple())
+            .trim()
+            .split(',')
+            .collect_tuple()
             .ok_or_else(parse_error)?;
 
         let (database, user, password, hostname, _, port) = conn_params;

--- a/ichiran/src/server.rs
+++ b/ichiran/src/server.rs
@@ -1,0 +1,250 @@
+//! Persistent ichiran-cli worker pool.
+//!
+//! Each worker owns a long-lived `ichiran-cli -e <SERVER_LOOP>` process. Requests are
+//! base64-line framed (one line per direction); each worker handles one request at a
+//! time, so the protocol does not need request ids. The pool fans concurrent requests
+//! across workers via a shared mpmc queue.
+
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+    sync::Arc,
+    time::Instant,
+};
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::Command,
+    sync::{mpsc, oneshot, Mutex},
+};
+use tracing::{Instrument, Level};
+
+use crate::error::IchiranError;
+
+/// Truncate a sexp for log output so we don't spam the trace with
+/// multi-kilobyte JSON payloads.
+fn sexp_head(s: &str) -> String {
+    const LIMIT: usize = 80;
+    let mut head: String = s.chars().take(LIMIT).collect();
+    if s.chars().count() > LIMIT {
+        head.push_str("...");
+    }
+    head
+}
+
+// Capture *standard-output* during eval and return it as the response payload.
+// All callers must write their result via `(princ ...)` / `(format t ...)`;
+// the value returned by the form is discarded.
+const SERVER_LOOP: &str = r#"(progn
+  (write-line "READY")
+  (force-output)
+  (loop for line = (read-line *standard-input* nil nil)
+        while line
+        do (let ((form-str (sb-ext:octets-to-string
+                             (cl-base64:base64-string-to-usb8-array line)
+                             :external-format :utf-8)))
+             (handler-case
+                 (let* ((buf (make-string-output-stream))
+                        (out (progn
+                               (let ((*standard-output* buf))
+                                 (eval (read-from-string form-str)))
+                               (get-output-stream-string buf)))
+                        (out64 (cl-base64:usb8-array-to-base64-string
+                                 (sb-ext:string-to-octets out :external-format :utf-8))))
+                   (format t "ok ~A~%" out64))
+               (error (e)
+                 (let ((msg64 (cl-base64:usb8-array-to-base64-string
+                                (sb-ext:string-to-octets (prin1-to-string e) :external-format :utf-8))))
+                   (format t "err ~A~%" msg64))))
+             (force-output))))"#;
+
+type Reply = oneshot::Sender<Result<String, IchiranError>>;
+
+struct Request {
+    sexp: String,
+    reply: Reply,
+    /// Span representing the caller's `evaluate` invocation. The worker enters
+    /// it while servicing the request so `lisp.write`, `lisp.read` etc. show
+    /// up nested under the original call site.
+    span: tracing::Span,
+    /// When the request was enqueued, used to log queue wait time.
+    enqueued_at: Instant,
+}
+
+type WorkQueue = Arc<Mutex<mpsc::Receiver<Request>>>;
+
+pub struct IchiranPool {
+    tx: mpsc::Sender<Request>,
+}
+
+impl IchiranPool {
+    #[tracing::instrument(level = Level::INFO, skip_all, fields(?path, size), err)]
+    pub async fn spawn(path: &Path, size: usize) -> Result<Self, IchiranError> {
+        assert!(size >= 1, "pool size must be >= 1");
+        path.parent().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not find working directory of ichiran-cli",
+            )
+        })?;
+
+        let (tx, rx) = mpsc::channel::<Request>(size * 4);
+        let queue: WorkQueue = Arc::new(Mutex::new(rx));
+
+        for worker_id in 0..size {
+            spawn_worker(worker_id, path.to_owned(), queue.clone()).await?;
+        }
+
+        tracing::info!(size, "ichiran-cli pool ready");
+        Ok(Self { tx })
+    }
+
+    #[tracing::instrument(level = Level::DEBUG, skip_all, fields(sexp = %sexp_head(&sexp)), err)]
+    pub async fn evaluate(&self, sexp: String) -> Result<String, IchiranError> {
+        tracing::trace!(%sexp, "evaluate");
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let span = tracing::Span::current();
+        let enqueued_at = Instant::now();
+        self.tx
+            .send(Request {
+                sexp,
+                reply: reply_tx,
+                span,
+                enqueued_at,
+            })
+            .await
+            .map_err(|_| IchiranError::ServerGone)?;
+        reply_rx.await.map_err(|_| IchiranError::ServerGone)?
+    }
+}
+
+async fn spawn_worker(
+    worker_id: usize,
+    path: PathBuf,
+    queue: WorkQueue,
+) -> Result<(), IchiranError> {
+    let working_dir = path.parent().unwrap();
+    let mut child = Command::new(&path)
+        .current_dir(working_dir)
+        .arg("-e")
+        .arg(SERVER_LOOP)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut reader = BufReader::new(stdout);
+
+    // Wait for READY handshake. Skip any preamble lines (banner, NIL, etc).
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Err(IchiranError::Server(format!(
+                "ichiran-cli worker {worker_id} exited before READY"
+            )));
+        }
+        if line.trim_end() == "READY" {
+            break;
+        }
+        tracing::debug!(worker_id, line = %line.trim_end(), "ichiran-cli preamble");
+    }
+
+    tracing::info!(worker_id, pid = ?child.id(), "ichiran-cli worker ready");
+
+    tokio::spawn(worker_loop(worker_id, child, stdin, reader, queue));
+    Ok(())
+}
+
+async fn worker_loop(
+    worker_id: usize,
+    mut child: tokio::process::Child,
+    mut stdin: tokio::process::ChildStdin,
+    mut reader: BufReader<tokio::process::ChildStdout>,
+    queue: WorkQueue,
+) {
+    loop {
+        // Hold the lock only long enough to pop one request, then release before
+        // processing so other workers can grab the next one.
+        let req = {
+            let mut rx = queue.lock().await;
+            match rx.recv().await {
+                Some(r) => r,
+                None => break,
+            }
+        };
+
+        // Service the request inside the caller's span so events nest under
+        // the original `evaluate` call.
+        let parent_span = req.span.clone();
+        let queue_wait_ms = req.enqueued_at.elapsed().as_millis() as u64;
+        let result = handle_request(&mut stdin, &mut reader, &req.sexp, worker_id, queue_wait_ms)
+            .instrument(parent_span)
+            .await;
+
+        // Decide whether to bail before consuming the result via send().
+        let fatal = matches!(result, Err(IchiranError::ServerGone));
+        if req.reply.send(result).is_err() {
+            tracing::debug!(worker_id, "request dropped before reply");
+        }
+        if fatal {
+            break;
+        }
+    }
+
+    tracing::warn!(worker_id, "ichiran-cli worker loop exiting");
+    let _ = child.start_kill();
+}
+
+async fn handle_request(
+    stdin: &mut tokio::process::ChildStdin,
+    reader: &mut BufReader<tokio::process::ChildStdout>,
+    sexp: &str,
+    worker_id: usize,
+    queue_wait_ms: u64,
+) -> Result<String, IchiranError> {
+    let b64 = B64.encode(sexp.as_bytes());
+    let mut frame = b64.into_bytes();
+    frame.push(b'\n');
+
+    let lisp_start = Instant::now();
+    stdin.write_all(&frame).await?;
+    stdin.flush().await?;
+
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).await?;
+    if n == 0 {
+        return Err(IchiranError::ServerGone);
+    }
+    let lisp_ms = lisp_start.elapsed().as_millis() as u64;
+    tracing::debug!(
+        worker_id,
+        lisp_ms,
+        queue_wait_ms,
+        bytes_in = frame.len(),
+        bytes_out = n,
+        "ichiran.call"
+    );
+
+    parse_response(line.trim_end())
+}
+
+fn parse_response(line: &str) -> Result<String, IchiranError> {
+    let (tag, b64) = line
+        .split_once(' ')
+        .ok_or_else(|| IchiranError::Server(format!("malformed frame: {line}")))?;
+    let bytes = B64
+        .decode(b64)
+        .map_err(|e| IchiranError::Server(format!("invalid base64: {e}")))?;
+    let payload = String::from_utf8(bytes)
+        .map_err(|e| IchiranError::Server(format!("invalid utf-8: {e}")))?;
+    match tag {
+        "ok" => Ok(payload),
+        "err" => Err(IchiranError::Server(payload)),
+        other => Err(IchiranError::Server(format!("unknown tag: {other}"))),
+    }
+}

--- a/ichiran/src/tests/fixture/mod.rs
+++ b/ichiran/src/tests/fixture/mod.rs
@@ -6,5 +6,5 @@ pub async fn ichiran() -> Ichiran {
     let ichiran_path =
         PathBuf::from("../data/ichiran-cli").with_extension(std::env::consts::EXE_EXTENSION);
 
-    Ichiran::new(ichiran_path)
+    Ichiran::new(ichiran_path, crate::default_pool_size())
 }

--- a/niinii/src/parser.rs
+++ b/niinii/src/parser.rs
@@ -17,6 +17,9 @@ pub enum Error {
 pub struct SyntaxTree {
     pub original_text: String,
     pub root: Root,
+    /// Filled in asynchronously after the AST is displayable. May be empty
+    /// while a kanji-info fetch is still in flight; callers must tolerate
+    /// missing entries.
     pub kanji_info: HashMap<char, Kanji>,
     pub jmdict_data: JmDictData,
 }
@@ -36,7 +39,7 @@ struct Shared {
 }
 impl Parser {
     pub async fn new(settings: &Settings) -> Self {
-        let ichiran = Ichiran::new(settings.ichiran_path.clone());
+        let ichiran = Ichiran::new(settings.ichiran_path.clone(), settings.ichiran_pool_size);
         let pg_daemon = match ichiran.conn_params().await {
             Ok(conn_params) => {
                 let pg_daemon = PostgresDaemon::new(
@@ -59,7 +62,11 @@ impl Parser {
             }),
         }
     }
-    pub async fn parse(
+    /// Parse the AST for display. Skips kanji info, which is fetched
+    /// separately via `parse_kanji` and merged into the tree once it
+    /// arrives. This is the latency-critical path: the AST renders as
+    /// soon as romanize returns.
+    pub async fn parse_ast(
         &self,
         text: &str,
         splits: &[(Split, String)],
@@ -67,17 +74,22 @@ impl Parser {
     ) -> Result<SyntaxTree, Error> {
         let ichiran = &self.shared.ichiran;
 
-        let (root, kanji_info, jmdict_data) = tokio::try_join!(
+        let (root, jmdict_data) = tokio::try_join!(
             ichiran.romanize(splits, variants),
-            ichiran.kanji_from_str(text),
-            ichiran.jmdict_data()
+            ichiran.jmdict_data(),
         )?;
 
         Ok(SyntaxTree {
             root,
-            kanji_info,
+            kanji_info: HashMap::new(),
             jmdict_data,
             original_text: text.to_string(),
         })
+    }
+
+    /// Fetch per-character kanji info for `text`. Runs concurrently with
+    /// `parse_ast` and contends for the same ichiran-cli pool.
+    pub async fn parse_kanji(&self, text: &str) -> Result<HashMap<char, Kanji>, Error> {
+        Ok(self.shared.ichiran.kanji_from_str(text).await?)
     }
 }

--- a/niinii/src/settings.rs
+++ b/niinii/src/settings.rs
@@ -76,6 +76,7 @@ impl Default for ChatSettings {
 #[serde(default)]
 pub struct Settings {
     pub ichiran_path: String,
+    pub ichiran_pool_size: usize,
     pub postgres_path: String,
     pub db_path: String,
 
@@ -111,6 +112,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             ichiran_path: "data/ichiran-cli.exe".into(),
+            ichiran_pool_size: ichiran::default_pool_size(),
             postgres_path: "data/pgsql/bin".into(),
             db_path: "data/pgsql/data".into(),
 

--- a/niinii/src/view/gloss.rs
+++ b/niinii/src/view/gloss.rs
@@ -16,11 +16,15 @@ use crate::settings::{RubyTextType, Settings};
 use crate::support::regex::CachedRegex;
 use crate::view::{raw::RawView, term::TermView};
 
-const CLIPBOARD_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const CLIPBOARD_POLL_INTERVAL: Duration = Duration::from_millis(33);
 
 enum View {
-    Text(String), // TODO: display basic_split instead of plain text
-    Interpret { ast: SyntaxTree },
+    /// Preview shown while a parse is in flight: the text chunked by
+    /// `basic_split` so Text/Skip blocks can be styled distinctly.
+    Text(Vec<(Split, String)>),
+    Interpret {
+        ast: SyntaxTree,
+    },
 }
 
 /// Emitted from `GlossView::poll`. `ClipboardReceived` surfaces new clipboard
@@ -40,7 +44,8 @@ pub enum GlossInputAction {
 
 pub struct GlossView {
     parser: Parser,
-    pending: Option<JoinHandle<Result<SyntaxTree, parser::Error>>>,
+    pending_ast: Option<JoinHandle<Result<SyntaxTree, parser::Error>>>,
+    pending_kanji: Option<JoinHandle<Result<HashMap<char, Kanji>, parser::Error>>>,
     match_regex: CachedRegex,
 
     input_text: String,
@@ -60,7 +65,8 @@ impl GlossView {
     pub async fn new(settings: &Settings) -> Self {
         Self {
             parser: Parser::new(settings).await,
-            pending: None,
+            pending_ast: None,
+            pending_kanji: None,
             match_regex: CachedRegex::default(),
             input_text: String::new(),
             last_clipboard: String::new(),
@@ -83,7 +89,8 @@ impl GlossView {
     }
 
     pub fn is_processing(&self) -> bool {
-        self.pending.is_some()
+        // Only block the input on the AST; kanji info loads in the background.
+        self.pending_ast.is_some()
     }
 
     pub fn input_text(&self) -> &str {
@@ -104,27 +111,45 @@ impl GlossView {
         let text = regex
             .replace_all(text, &settings.regex_replace)
             .into_owned();
-        let text = text.trim().to_owned();
+        // VN/clipboard text often arrives with hard line breaks from dialogue
+        // wrapping; ichiran segments per-line so embedded newlines wreck the
+        // parse. Strip them along with leading/trailing whitespace.
+        let text = text
+            .replace(|c: char| c == '\n' || c == '\r', "")
+            .trim()
+            .to_owned();
         if text.is_empty() {
             return Ok(None);
         }
 
-        if let Some(prev) = self.pending.take() {
+        if let Some(prev) = self.pending_ast.take() {
             prev.abort();
         }
-        self.view = Some(View::Text(text.clone()));
+        if let Some(prev) = self.pending_kanji.take() {
+            prev.abort();
+        }
 
-        let parser = self.parser.clone();
         let variants = if settings.more_variants { 5 } else { 1 };
-        let spawn_text = text.clone();
-        let splits: Vec<(Split, String)> = basic_split(&spawn_text)
+        let splits: Vec<(Split, String)> = basic_split(&text)
             .into_iter()
             .map(|(kind, s)| (kind, s.to_string()))
             .collect();
-        self.pending = Some(tokio::spawn(
-            async move { parser.parse(&spawn_text, &splits, variants).await }
-                .instrument(tracing::debug_span!("parse")),
+        self.view = Some(View::Text(splits.clone()));
+
+        let parser_ast = self.parser.clone();
+        let ast_text = text.clone();
+        self.pending_ast = Some(tokio::spawn(
+            async move { parser_ast.parse_ast(&ast_text, &splits, variants).await }
+                .instrument(tracing::debug_span!("parse_ast")),
         ));
+
+        let parser_kanji = self.parser.clone();
+        let kanji_text = text.clone();
+        self.pending_kanji = Some(tokio::spawn(
+            async move { parser_kanji.parse_kanji(&kanji_text).await }
+                .instrument(tracing::debug_span!("parse_kanji")),
+        ));
+
         Ok(Some(text))
     }
 
@@ -147,9 +172,9 @@ impl GlossView {
             }
         }
 
-        if let Some(handle) = self.pending.as_mut() {
+        if let Some(handle) = self.pending_ast.as_mut() {
             if let Some(poll) = handle.now_or_never() {
-                self.pending = None;
+                self.pending_ast = None;
                 match poll {
                     Ok(Ok(ast)) => {
                         if ctx.flags().contains(ContextFlags::SUPPORTS_ATLAS_UPDATE) {
@@ -160,6 +185,21 @@ impl GlossView {
                     Ok(Err(err)) => self.events.push_back(GlossEvent::Failed(err)),
                     // Aborted by a follow-up request; the replacement is already in flight.
                     Err(_) => {}
+                }
+            }
+        }
+
+        // Only drain kanji once the AST has landed -- the JoinHandle holds a
+        // completed result for us, so there's no need for a separate buffer.
+        if let Some(View::Interpret { ast, .. }) = &mut self.view {
+            if let Some(handle) = self.pending_kanji.as_mut() {
+                if let Some(poll) = handle.now_or_never() {
+                    self.pending_kanji = None;
+                    match poll {
+                        Ok(Ok(kanji_info)) => ast.kanji_info = kanji_info,
+                        Ok(Err(err)) => self.events.push_back(GlossEvent::Failed(err)),
+                        Err(_) => {}
+                    }
                 }
             }
         }
@@ -251,6 +291,28 @@ impl GlossView {
                 highlight: false,
                 stroke: !preview && settings.stroke_text,
                 preview,
+                underline: UnderlineMode::None,
+            },
+        );
+    }
+
+    /// Render a text chunk that will be glossed once the parse finishes.
+    /// Drawn with `highlight: true` so it visually hints at the eventual
+    /// clause boxes.
+    fn add_preview_text(&self, ctx: &mut Context, ui: &Ui, settings: &Settings, text: &str) {
+        draw_kanji_text(
+            ui,
+            ctx,
+            text,
+            if settings.ruby_text_type == RubyTextType::None {
+                RubyTextMode::None
+            } else {
+                RubyTextMode::Pad
+            },
+            KanjiStyle {
+                highlight: true,
+                stroke: false,
+                preview: true,
                 underline: UnderlineMode::None,
             },
         );
@@ -394,8 +456,13 @@ impl GlossView {
                         });
                 }
             }
-            Some(View::Text(text)) => {
-                self.add_skipped(ctx, ui, settings, text, true);
+            Some(View::Text(splits)) => {
+                for (kind, chunk) in splits {
+                    match kind {
+                        Split::Text => self.add_preview_text(ctx, ui, settings, chunk),
+                        Split::Skip => self.add_skipped(ctx, ui, settings, chunk, true),
+                    }
+                }
             }
             _ => {}
         }

--- a/niinii/src/view/settings.rs
+++ b/niinii/src/view/settings.rs
@@ -52,6 +52,22 @@ impl SettingsView {
             ui.input_text("db*", &mut settings.db_path).build();
             ui.same_line();
             mixins::help_marker(ui, "Path of postgres database directory");
+
+            let mut pool_size = settings.ichiran_pool_size as i32;
+            if ui
+                .input_int("pool size*", &mut pool_size)
+                .step(1)
+                .build()
+            {
+                settings.ichiran_pool_size = pool_size.max(1) as usize;
+            }
+            ui.same_line();
+            mixins::help_marker(
+                ui,
+                "Number of resident ichiran-cli workers. \
+                 More = better parse parallelism, but each worker holds a Postgres \
+                 connection. Takes effect on restart.",
+            );
         }
 
         if CollapsingHeader::new("Advanced")

--- a/niinii/src/view/translator/chat.rs
+++ b/niinii/src/view/translator/chat.rs
@@ -348,13 +348,13 @@ fn draw_exchange(ui: &Ui, ex: &ExchangeView) {
     ui.text(""); // anchor for line wrapping
     ui.same_line();
     let draw_list = ui.get_window_draw_list();
-    stroke_text_with_highlight(
-        ui,
-        &draw_list,
-        &format!("[{}]", ex.model.as_ref()),
-        1.0,
-        Some(StyleColor::NavHighlight),
-    );
+    // stroke_text_with_highlight(
+    //     ui,
+    //     &draw_list,
+    //     &format!("[{}]", ex.model.as_ref()),
+    //     1.0,
+    //     Some(StyleColor::NavHighlight),
+    // );
     let content = ex.response.content();
     if !content.is_empty() {
         ui.same_line();

--- a/openai/src/lib.rs
+++ b/openai/src/lib.rs
@@ -99,6 +99,14 @@ impl Client {
                 client: reqwest::Client::builder()
                     .timeout(connection_policy.timeout)
                     .connect_timeout(connection_policy.connect_timeout)
+                    // Keep the TLS/HTTP-2 connection to the chat endpoint hot
+                    // so the first translation token after an idle period
+                    // does not pay TCP+TLS handshake latency.
+                    .pool_idle_timeout(None)
+                    .tcp_keepalive(Duration::from_secs(30))
+                    .http2_keep_alive_interval(Duration::from_secs(30))
+                    .http2_keep_alive_timeout(Duration::from_secs(10))
+                    .http2_keep_alive_while_idle(true)
                     .build()
                     .unwrap(),
                 api_base,


### PR DESCRIPTION
- Use worker pool for ichiran-cli to reduce latency
    - Use `ichiran-cli -e` to inject a REPL style service to process requests
- Explicitly set HTTP/2 keepalive when idle for translation to reduce latency

Saves on the order of 200ms from clipboard update to screen draw which I'm pretty happy with.